### PR TITLE
Minor mode lighter should start with space

### DIFF
--- a/use-proxy.el
+++ b/use-proxy.el
@@ -154,7 +154,7 @@ Argument PROTO protocol which you want to get proxy of."
     (error "%s proxy is not supported yet" proto)))
 
 (defun use-proxy--modeline-string ()
-  (format "proxy[%s]%s"
+  (format " proxy[%s]%s"
           (string-join
            (mapcar #'car
                    (seq-filter


### PR DESCRIPTION
#### before

![before](https://user-images.githubusercontent.com/554281/92353763-fa103a80-f11b-11ea-9512-c61674b4b2bd.jpg)

#### after

![after](https://user-images.githubusercontent.com/554281/92353792-085e5680-f11c-11ea-9a52-46379a30a384.jpg)
